### PR TITLE
Use prettier for styling rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-config-civicsource",
   "description": "Shareable ESLint configuration to be used in CivicSource client applications",
   "main": "index.js",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/civicsource/eslint-config-civicsource.git"
@@ -23,6 +23,8 @@
     "eslint-plugin-flowtype": "2.x",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "2.x",
-    "eslint-plugin-react": "6.x"
+    "eslint-plugin-prettier": "2.x",
+    "eslint-plugin-react": "6.x",
+    "prettier": "1.x"
   }
 }

--- a/react.js
+++ b/react.js
@@ -13,10 +13,6 @@ module.exports = {
 
 		// ERRORS
 
-		// use double quotes like a gentleman (or a lady)
-		// http://eslint.org/docs/rules/jsx-quotes
-		"jsx-quotes": ["error", "prefer-double"],
-
 		// don't write components like a n00b
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
 		"react/prefer-stateless-function": ["error"],
@@ -24,10 +20,6 @@ module.exports = {
 		// don't write components like a n00b
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
 		"react/prefer-es6-class": ["error", "always"],
-
-		// wrap multiline jsx in parens
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md
-		"react/jsx-wrap-multilines": ["error"],
 
 		// put stuff in order
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
@@ -40,26 +32,6 @@ module.exports = {
 		// don't use bools like a n00b
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
 		"react/jsx-boolean-value": ["error", "never"],
-
-		// indent components like sane human
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
-		"react/jsx-indent": ["error", "tab"],
-
-		// indent props like a sane human
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
-		"react/jsx-indent-props": ["error", "tab"],
-
-		// don't be weird about spaces for jsx props
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
-		"react/jsx-curly-spacing": ["error", "never"],
-
-		// don't be weird about spacing around equal signs in jsx props
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
-		"react/jsx-equals-spacing": ["error", "never"],
-
-		// put a space at the end of your component - THINK OF THE CHILDREN
-		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
-		"react/jsx-space-before-closing": ["error"],
 
 		// don't waste half a day debugging because you decided to use an array index to key a list
 		// https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md

--- a/style.js
+++ b/style.js
@@ -1,61 +1,14 @@
 module.exports = {
 	plugins: [
-		"filenames"
+		"filenames",
+		"prettier"
 	],
 	rules: {
 		// ERRORS
 
-		// we indent with tabs not spaces because we aren't a roving band of marauders
-		// http://eslint.org/docs/rules/indent
-		"indent": ["error", "tab", { SwitchCase: 1 }],
-
-		// enforce double quotes for strings
-		// http://eslint.org/docs/rules/quotes
-		"quotes": ["error", "double"],
-
-		// require semicolons
-		// http://eslint.org/docs/rules/semi
-		"semi": ["error", "always"],
-
-		// the "one true brace style"
-		// http://eslint.org/docs/rules/brace-style
-		"brace-style": ["error", "1tbs", { allowSingleLine: true }],
-
-		// don't jumble everything together inside of code blocks
-		// http://eslint.org/docs/rules/block-spacing
-		"block-spacing": ["error", "always"],
-
-		// don't jumble the start of code blocks together
-		// http://eslint.org/docs/rules/space-before-blocks
-		"space-before-blocks": ["error", "always"],
-
-		// don't jumble everything together inside of object definitions
-		// http://eslint.org/docs/rules/object-curly-spacing
-		"object-curly-spacing": ["error", "always"],
-
-		// spaces before & after =>
-		// http://eslint.org/docs/rules/arrow-spacing
-		"arrow-spacing": ["error"],
-
-		// object keys: one space after, none before
-		// http://eslint.org/docs/rules/key-spacing
-		"key-spacing": ["error"],
-
-		// don't jumble keywords
-		// http://eslint.org/docs/rules/keyword-spacing
-		"keyword-spacing": ["error"],
-
-		// don't leave little turds of whitespace at the end of lines
-		// http://eslint.org/docs/rules/no-trailing-spaces
-		"no-trailing-spaces": ["error"],
-
-		// put a space after the comment slashes
-		// http://eslint.org/docs/rules/spaced-comment
-		"spaced-comment": ["error", "always"],
-
-		// don't do weird stuff with dot notation
-		// http://eslint.org/docs/rules/no-whitespace-before-property
-		"no-whitespace-before-property": ["error"],
+		// No more bikeshedding on style; just use prettier
+		// https://github.com/not-an-aardvark/eslint-plugin-prettier
+		"prettier/prettier": ["error", { useTabs: true }],
 
 		// enforce lowercase kebab case for filenames
 		// we have had issues in the past with case sensitivity & module resolution
@@ -65,10 +18,6 @@ module.exports = {
 		// don't concatenate strings like a n00b
 		// http://eslint.org/docs/rules/prefer-template
 		"prefer-template": ["error"],
-
-		// force curly braces for control-flow blocks unless it is single line
-		// http://eslint.org/docs/rules/curly
-		"curly": ["error", "multi-line"],
 
 		// =======================================================================================
 		// WARNINGS


### PR DESCRIPTION
Replace all styling rules with [prettier](https://github.com/prettier/prettier). It catches more things, is fixable, & will eliminate bike shedding on code formatting.

Hint: for a good time, enable `eslint.autoFixOnSave` in your VS Code settings:

```json
{
  "eslint.autoFixOnSave": true
}
```