### PR TITLE
Reenable brace style rule for control flow blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-config-civicsource",
   "description": "Shareable ESLint configuration to be used in CivicSource client applications",
   "main": "index.js",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/civicsource/eslint-config-civicsource.git"

--- a/style.js
+++ b/style.js
@@ -23,6 +23,10 @@ module.exports = {
 		// http://eslint.org/docs/rules/spaced-comment
 		"spaced-comment": ["error", "always"],
 
+		// force curly braces for control-flow blocks unless it is single line
+		// http://eslint.org/docs/rules/curly
+		"curly": ["error", "multi-line", "consistent"],
+
 		// =======================================================================================
 		// WARNINGS
 


### PR DESCRIPTION
Inspired by @broline in civicsource/administrator#172.

Prettier doesn't opininate on braces for control flow blocks (it'll just use whatever you put).

Minor version bump since it is fixable.