### PR TITLE
Don't include any environments by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,5 @@
 module.exports = {
 	parser: "babel-eslint",
-	env: {
-		browser: true,
-		commonjs: true,
-		es6: true,
-		node: true
-	},
 	extends: [
 		"eslint:recommended",
 		"civicsource/imports",

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "civicsource"
   ],
   "peerDependencies": {
-    "eslint": ">= 3"
+    "eslint": ">= 3 < 5"
   },
   "dependencies": {
-    "babel-eslint": "7.x",
+    "babel-eslint": "8.x",
     "eslint-plugin-filenames": "1.x",
     "eslint-plugin-flowtype": "2.x",
     "eslint-plugin-import": "2.x",
-    "eslint-plugin-jsx-a11y": "5.x",
+    "eslint-plugin-jsx-a11y": "6.x",
     "eslint-plugin-mocha": "4.x",
     "eslint-plugin-prettier": "2.x",
     "eslint-plugin-react": "7.x",


### PR DESCRIPTION
Force consuming packages to specify their own environments rather than over-specifying here. This in preparation for the great server rendering revolution coming where we need to define different environments depending on the subfolder of the project.

Also, upgrading some stuff. See the list of [breaking changes for eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y/releases/tag/v6.0.0). I don't think we are affected by any of those.