### PR TITLE
Upgrade dependencies, move prettier to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint-plugin-mocha": "5.x",
     "eslint-plugin-prettier": "3.x",
     "eslint-plugin-react": "7.x",
-    "eslint-plugin-react-functional-set-state": "1.x",
-    "prettier": "1.x"
+    "eslint-plugin-react-functional-set-state": "1.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,16 +15,17 @@
     "civicsource"
   ],
   "peerDependencies": {
-    "eslint": ">= 3 < 5"
+    "eslint": "5.x",
+    "prettier": "1.x"
   },
   "dependencies": {
-    "babel-eslint": "8.x",
+    "babel-eslint": "10.x",
     "eslint-plugin-filenames": "1.x",
     "eslint-plugin-flowtype": "2.x",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-jsx-a11y": "6.x",
-    "eslint-plugin-mocha": "4.x",
-    "eslint-plugin-prettier": "2.x",
+    "eslint-plugin-mocha": "5.x",
+    "eslint-plugin-prettier": "3.x",
     "eslint-plugin-react": "7.x",
     "eslint-plugin-react-functional-set-state": "1.x",
     "prettier": "1.x"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "civicsource"
   ],
   "peerDependencies": {
-    "eslint": "5.x",
+    "eslint": "5.x"
+  },
+  "devDependencies": {
     "prettier": "1.x"
   },
   "dependencies": {


### PR DESCRIPTION
Upgrades babel-eslint & eslint & gives us access to a host of new rules & features ([full changelog](https://github.com/eslint/eslint/blob/master/CHANGELOG.md)).

The most immediately visible being code frames in linter output so you can see the context of the rule violation before opening the file.